### PR TITLE
Enable accelerated networking

### DIFF
--- a/008-variables.tf
+++ b/008-variables.tf
@@ -209,6 +209,11 @@ variable "additional_script_uri" {
 variable "additional_script_name" {
   default = null
 }
+
+variable "accelerated_networking_enabled" {
+  default = false
+}
+
 variable "tags" {}
 
 locals {

--- a/020-networking.tf
+++ b/020-networking.tf
@@ -1,8 +1,9 @@
 
 resource "azurerm_network_interface" "vm_nic" {
-  name                = var.nic_name
-  location            = var.vm_location
-  resource_group_name = var.vm_resource_group
+  name                          = var.nic_name
+  location                      = var.vm_location
+  resource_group_name           = var.vm_resource_group
+  enable_accelerated_networking = var.accelerated_networking_enabled
 
   ip_configuration {
     name                          = var.ipconfig_name


### PR DESCRIPTION
### Change description ###
I want to use this module to build my vms but I need to have accelerated networking enabled

https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface#enable_accelerated_networking

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
