### PR TITLE
Add custom_data field to vms

### DIFF
--- a/008-variables.tf
+++ b/008-variables.tf
@@ -214,6 +214,10 @@ variable "accelerated_networking_enabled" {
   default = false
 }
 
+variable "custom_data" {
+  default = null
+}
+
 variable "tags" {}
 
 locals {

--- a/010-main.tf
+++ b/010-main.tf
@@ -7,6 +7,7 @@ resource "azurerm_windows_virtual_machine" "winvm" {
   admin_username      = var.vm_admin_name
   admin_password      = var.vm_admin_password
   zone                = var.vm_availabilty_zones
+  custom_data         = var.custom_data
   network_interface_ids = [
     azurerm_network_interface.vm_nic.id,
   ]
@@ -53,6 +54,7 @@ resource "azurerm_linux_virtual_machine" "linvm" {
   admin_username                  = var.vm_admin_name
   admin_password                  = var.vm_admin_password
   zone                            = var.vm_availabilty_zones
+  custom_data                     = var.custom_data
   disable_password_authentication = false
   network_interface_ids = [
     azurerm_network_interface.vm_nic.id,


### PR DESCRIPTION
### Change description ###
I want to run scripts on my machines after they've been built. To do this, I can add a vm extension that will run a script that has been pre-loaded to the vm.
I want to add this field so that I can pre-load a file to my vm.

available on linux and windows, details:
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine#custom_data
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/windows_virtual_machine#custom_data

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
